### PR TITLE
Issue #2: Do not serialize JSON string as custom string

### DIFF
--- a/src/main/kotlin/dev/dnpm/etl/processor/output/RestMtbFileSender.kt
+++ b/src/main/kotlin/dev/dnpm/etl/processor/output/RestMtbFileSender.kt
@@ -50,7 +50,7 @@ class RestMtbFileSender(
                 return MtbFileSender.Response(response.statusCode.asRequestStatus(), "Status-Code: ${response.statusCode.value()}")
             }
             logger.debug("Sent file via RestMtbFileSender")
-            return MtbFileSender.Response(response.statusCode.asRequestStatus())
+            return MtbFileSender.Response(response.statusCode.asRequestStatus(), response.body.orEmpty())
         } catch (e: IllegalArgumentException) {
             logger.error("Not a valid URI to export to: '{}'", restTargetProperties.uri!!)
         } catch (e: RestClientException) {

--- a/src/main/kotlin/dev/dnpm/etl/processor/services/ResponseProcessor.kt
+++ b/src/main/kotlin/dev/dnpm/etl/processor/services/ResponseProcessor.kt
@@ -55,14 +55,14 @@ class ResponseProcessor(
                 RequestStatus.WARNING -> {
                     it.report = Report(
                         "Warnungen über mangelhafte Daten",
-                        objectMapper.writeValueAsString(event.body)
+                        event.body.orElse("")
                     )
                 }
 
                 RequestStatus.ERROR -> {
                     it.report = Report(
                         "Fehler bei der Datenübertragung oder Inhalt nicht verarbeitbar",
-                        objectMapper.writeValueAsString(event.body)
+                        event.body.orElse("")
                     )
                 }
 


### PR DESCRIPTION
In addition to that, if REST request did not contain a response body, use empty string as data quality report string.