### PR TITLE
Issue #3: Detect the request type of request with last known status

### DIFF
--- a/src/integrationTest/kotlin/dev/dnpm/etl/processor/services/RequestServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/dev/dnpm/etl/processor/services/RequestServiceIntegrationTest.kt
@@ -116,7 +116,7 @@ class RequestServiceIntegrationTest : AbstractTestcontainerTest() {
     fun shouldReturnDeleteRequestAsLastRequest() {
         setupTestData()
 
-        val actual = requestService.isLastRequestDeletion("TEST_12345678901")
+        val actual = requestService.isLastRequestWithKnownStatusDeletion("TEST_12345678901")
 
         assertThat(actual).isTrue()
     }

--- a/src/main/kotlin/dev/dnpm/etl/processor/services/RequestProcessor.kt
+++ b/src/main/kotlin/dev/dnpm/etl/processor/services/RequestProcessor.kt
@@ -95,7 +95,7 @@ class RequestProcessor(
     private fun isDuplication(pseudonymizedMtbFile: MtbFile): Boolean {
         val lastMtbFileRequestForPatient =
             requestService.lastMtbFileRequestForPatientPseudonym(pseudonymizedMtbFile.patient.id)
-        val isLastRequestDeletion = requestService.isLastRequestDeletion(pseudonymizedMtbFile.patient.id)
+        val isLastRequestDeletion = requestService.isLastRequestWithKnownStatusDeletion(pseudonymizedMtbFile.patient.id)
 
         return null != lastMtbFileRequestForPatient
                 && !isLastRequestDeletion

--- a/src/main/kotlin/dev/dnpm/etl/processor/services/RequestService.kt
+++ b/src/main/kotlin/dev/dnpm/etl/processor/services/RequestService.kt
@@ -38,8 +38,8 @@ class RequestService(
     fun lastMtbFileRequestForPatientPseudonym(patientPseudonym: String) =
         Companion.lastMtbFileRequestForPatientPseudonym(allRequestsByPatientPseudonym(patientPseudonym))
 
-    fun isLastRequestDeletion(patientPseudonym: String) =
-        Companion.isLastRequestDeletion(allRequestsByPatientPseudonym(patientPseudonym))
+    fun isLastRequestWithKnownStatusDeletion(patientPseudonym: String) =
+        Companion.isLastRequestWithKnownStatusDeletion(allRequestsByPatientPseudonym(patientPseudonym))
 
     companion object {
 
@@ -48,7 +48,8 @@ class RequestService(
             .sortedByDescending { it.processedAt }
             .firstOrNull { it.status == RequestStatus.SUCCESS || it.status == RequestStatus.WARNING }
 
-        fun isLastRequestDeletion(allRequests: List<Request>) = allRequests
+        fun isLastRequestWithKnownStatusDeletion(allRequests: List<Request>) = allRequests
+            .filter { it.status != RequestStatus.UNKNOWN }
             .maxByOrNull { it.processedAt }?.type == RequestType.DELETE
 
     }

--- a/src/test/kotlin/dev/dnpm/etl/processor/services/RequestProcessorTest.kt
+++ b/src/test/kotlin/dev/dnpm/etl/processor/services/RequestProcessorTest.kt
@@ -92,7 +92,7 @@ class RequestProcessorTest {
 
         doAnswer {
             false
-        }.`when`(requestService).isLastRequestDeletion(anyString())
+        }.`when`(requestService).isLastRequestWithKnownStatusDeletion(anyString())
 
         doAnswer {
             it.arguments[0] as String
@@ -147,7 +147,7 @@ class RequestProcessorTest {
 
         doAnswer {
             false
-        }.`when`(requestService).isLastRequestDeletion(anyString())
+        }.`when`(requestService).isLastRequestWithKnownStatusDeletion(anyString())
 
         doAnswer {
             it.arguments[0] as String
@@ -202,7 +202,7 @@ class RequestProcessorTest {
 
         doAnswer {
             false
-        }.`when`(requestService).isLastRequestDeletion(anyString())
+        }.`when`(requestService).isLastRequestWithKnownStatusDeletion(anyString())
 
         doAnswer {
             MtbFileSender.Response(status = RequestStatus.SUCCESS)
@@ -261,7 +261,7 @@ class RequestProcessorTest {
 
         doAnswer {
             false
-        }.`when`(requestService).isLastRequestDeletion(anyString())
+        }.`when`(requestService).isLastRequestWithKnownStatusDeletion(anyString())
 
         doAnswer {
             MtbFileSender.Response(status = RequestStatus.ERROR)

--- a/src/test/kotlin/dev/dnpm/etl/processor/services/RequestServiceTest.kt
+++ b/src/test/kotlin/dev/dnpm/etl/processor/services/RequestServiceTest.kt
@@ -68,23 +68,33 @@ class RequestServiceTest {
                 patientId = "TEST_12345678901",
                 pid = "P1",
                 fingerprint = "0123456789abcdef1",
-                type = RequestType.DELETE,
-                status = RequestStatus.SUCCESS,
-                processedAt = Instant.parse("2023-08-08T02:00:00Z")
-            ),
-            Request(
-                id = 1L,
-                uuid = UUID.randomUUID().toString(),
-                patientId = "TEST_12345678902",
-                pid = "P2",
-                fingerprint = "0123456789abcdef2",
                 type = RequestType.MTB_FILE,
                 status = RequestStatus.WARNING,
-                processedAt = Instant.parse("2023-08-08T00:00:00Z")
+                processedAt = Instant.parse("2023-07-07T00:00:00Z")
+            ),
+            Request(
+                id = 2L,
+                uuid = UUID.randomUUID().toString(),
+                patientId = "TEST_12345678901",
+                pid = "P1",
+                fingerprint = "0123456789abcdefd",
+                type = RequestType.DELETE,
+                status = RequestStatus.WARNING,
+                processedAt = Instant.parse("2023-07-07T02:00:00Z")
+            ),
+            Request(
+                id = 3L,
+                uuid = UUID.randomUUID().toString(),
+                patientId = "TEST_12345678901",
+                pid = "P1",
+                fingerprint = "0123456789abcdef1",
+                type = RequestType.MTB_FILE,
+                status = RequestStatus.UNKNOWN,
+                processedAt = Instant.parse("2023-08-11T00:00:00Z")
             )
         )
 
-        val actual = RequestService.isLastRequestDeletion(requests)
+        val actual = RequestService.isLastRequestWithKnownStatusDeletion(requests)
 
         assertThat(actual).isTrue()
     }
@@ -98,23 +108,33 @@ class RequestServiceTest {
                 patientId = "TEST_12345678901",
                 pid = "P1",
                 fingerprint = "0123456789abcdef1",
-                type = RequestType.DELETE,
-                status = RequestStatus.SUCCESS,
+                type = RequestType.MTB_FILE,
+                status = RequestStatus.WARNING,
+                processedAt = Instant.parse("2023-07-07T00:00:00Z")
+            ),
+            Request(
+                id = 2L,
+                uuid = UUID.randomUUID().toString(),
+                patientId = "TEST_12345678901",
+                pid = "P1",
+                fingerprint = "0123456789abcdef1",
+                type = RequestType.MTB_FILE,
+                status = RequestStatus.WARNING,
                 processedAt = Instant.parse("2023-07-07T02:00:00Z")
             ),
             Request(
-                id = 1L,
+                id = 3L,
                 uuid = UUID.randomUUID().toString(),
-                patientId = "TEST_12345678902",
-                pid = "P2",
-                fingerprint = "0123456789abcdef2",
+                patientId = "TEST_12345678901",
+                pid = "P1",
+                fingerprint = "0123456789abcdef1",
                 type = RequestType.MTB_FILE,
-                status = RequestStatus.WARNING,
-                processedAt = Instant.parse("2023-08-08T00:00:00Z")
+                status = RequestStatus.UNKNOWN,
+                processedAt = Instant.parse("2023-08-11T00:00:00Z")
             )
         )
 
-        val actual = RequestService.isLastRequestDeletion(requests)
+        val actual = RequestService.isLastRequestWithKnownStatusDeletion(requests)
 
         assertThat(actual).isFalse()
     }
@@ -197,7 +217,7 @@ class RequestServiceTest {
 
     @Test
     fun isLastRequestDeletionShouldRequestAllRequestsForPatientPseudonym() {
-        requestService.isLastRequestDeletion("TEST_12345678901")
+        requestService.isLastRequestWithKnownStatusDeletion("TEST_12345678901")
 
         verify(requestRepository, times(1)).findAllByPatientIdOrderByProcessedAtDesc(anyString())
     }


### PR DESCRIPTION
This will skip any requests with unknown state which might not successfully be sent to remote bwHC backend service. So no duplication will be detected until a known state is saved for a request.